### PR TITLE
make album grids responsive

### DIFF
--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -2,8 +2,8 @@
 <% if @albums.present? %>
 <div class="container">
   <div class="row justify-content-between">
-    <div class="col-6"><h2>Latest Music Releases</h2></div>
-    <div class="col-3 text-right">
+    <div class="col-sm-9"><h2>Latest Music Releases</h2></div>
+    <div class="col-sm-3 text-right">
       <div class="dropdown">
         <a href="#" class="dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Last <%= @num_days %> days</a>
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
@@ -21,7 +21,7 @@
       <div class="row">
       <% @albums.each do |a| %>
       <% cache a do %>
-      <div class="col-2 pb-4">
+      <div class="col-6 col-sm-4 col-md-3 col-lg-2 pb-4">
         <div class="card album">
           <div class="album_cover">
             <a href="<%= album_path(a) %>">
@@ -37,7 +37,7 @@
             <% end %>
           </div>
         </div>
-      </div>  
+      </div>
       <% end %>
       <% end %>
       </div>

--- a/app/views/albums/upcoming.html.erb
+++ b/app/views/albums/upcoming.html.erb
@@ -1,14 +1,14 @@
 <% title "Upcoming Releases" %>
 <div class="container">
     <div class="row justify-content-between">
-      <div class="col-6"><h2>Upcoming Releases</h2></div>
+      <div class="col-sm-9"><h2>Upcoming Releases</h2></div>
     </div>
     <div class="row">
       <div class="col-sm-12">
         <div class="row">
         <% @albums.each do |a| %>
         <% cache a do %>
-        <div class="col-2 pb-4">
+        <div class="col-6 col-sm-4 col-md-3 col-lg-2 pb-4">
           <div class="card album">
             <div class="album_cover">
               <a href="<%= album_path(a) %>">
@@ -24,7 +24,7 @@
               <% end %>
             </div>
           </div>
-        </div>  
+        </div>
         <% end %>
         <% end %>
         </div>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -9,8 +9,8 @@
           <li class="breadcrumb-item active" aria-current="page"><%= @artist.name %></li>
         </ol>
       </nav>
-      
-      <h1><%= @artist.name %> 
+
+      <h1><%= @artist.name %>
         <% if current_user %>
           <% if Follow.where(user: current_user, artist: @artist, active: true).present? %>
           <%= link_to "Unfollow", unfollow_artist_path(@artist), class: 'btn btn-outline-success', data: { confirm: "Are you sure?" } %>
@@ -19,7 +19,7 @@
           <% end %>
         <% end %>
       </h1>
-      
+
       <% if @artist.follows.present? %>
       <div class="row">
         <div class="col">
@@ -32,12 +32,15 @@
       <hr>
       <% end %>
       <div class="row">
-        <div class="col-<% if @artist.music_videos.present? %>7<% else %>12<% end %>">
+        <% releases_size_css = @artist.music_videos.present? ? "col-7" : "col-12" %>
+        <% album_size_css = @artist.music_videos.present? ? "col-sm-6 col-md-4 col-xl-3" : "col-6 col-sm-4 col-md-3 col-lg-2" %>
+        <div class="<%= releases_size_css %>">
           <h3>Releases</h3>
           <div class="row">
             <% @artist.albums.where.not(album_type: 'compilation').order(release_date: :desc, artist_id: :desc).limit(100).each do |a| %>
+
             <% cache a do %>
-            <div class="col-<% if @artist.music_videos.present? %>3<% else %>2<% end %> pb-4">
+            <div class="<%= album_size_css %> pb-4">
               <div class="card album">
                 <div class="album_cover">
                   <a href="<%= album_path(a) %>">
@@ -52,7 +55,7 @@
                   <% end %>
                 </div>
               </div>
-            </div>  
+            </div>
             <% end %>
             <% end %>
           </div>
@@ -62,7 +65,7 @@
           <h3>Music Videos</h3>
           <div class="row">
           <% @artist.music_videos.order('release_date desc').each do |video| %>
-              <div class="col-6 pb-4">
+              <div class="col-md-6 pb-4">
               <div class="card album">
                 <div class="album_cover">
                   <a href="<%= music_video_path(video) %>">

--- a/app/views/music_videos/index.html.erb
+++ b/app/views/music_videos/index.html.erb
@@ -2,8 +2,8 @@
 <% if @videos.present? %>
 <div class="container">
   <div class="row justify-content-between">
-    <div class="col-6"><h2>Latest Music Videos</h2></div>
-    <div class="col-3 text-right">
+    <div class="col-sm-9"><h2>Latest Music Videos</h2></div>
+    <div class="col-sm-3 text-right">
       <div class="dropdown">
         <a href="#" class="dropdown-toggle" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Last <%= @num_days %> days</a>
         <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
@@ -21,7 +21,7 @@
       <div class="row">
       <% @videos.each do |video| %>
       <% cache video do %>
-        <div class="col-3 pb-4">
+      <div class="col-6 col-sm-4 col-md-3 col-lg-2 pb-4">
         <div class="card album">
           <div class="album_cover">
             <a href="<%= music_video_path(video) %>">

--- a/app/views/news/index.html.erb
+++ b/app/views/news/index.html.erb
@@ -2,13 +2,13 @@
 <% if @news.present? %>
 <div class="container">
   <div class="row justify-content-between">
-    <div class="col-6"><h2>Latest Music News</h2></div>
+    <div class="col-sm-9"><h2>Latest Music News</h2></div>
   </div>
   <div class="row">
     <div class="col-sm-12">
       <div class="row">
         <% @news.each do |news| %>
-          <div class="col-4 pb-4">
+        <div class="col-6 col-sm-4 col-md-3 col-lg-2 pb-4">
           <div class="card album news">
             <div class="album_cover">
               <a href="<%= news.url %>">
@@ -22,7 +22,7 @@
               <p class="release-date"><small><%= news.published_at.strftime("%B %-e, %Y") %></small></p>
             </div>
           </div>
-          </div>
+        </div>
         <% end %>
       </div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -13,7 +13,7 @@
     <div class="row">
       <% @new_albums.each do |a| %>
       <% cache a do %>
-      <div class="col-sm-2 pb-4">
+      <div class="col-6 col-sm-4 col-md-3 col-lg-2 pb-4">
         <div class="card album">
           <div class="album_cover">
             <a href="<%= album_path(a) %>">
@@ -29,7 +29,7 @@
             <% end %>
           </div>
         </div>
-      </div>  
+      </div>
       <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
**Page titles** (like "Latest Music Releases")
- Made full width in XS screens.
- Made wider, previously `col-6`, extended to `col-9`, which still fits with dropdown on the right.

**Album grid** (present in multiple pages)
- Changed from fixed size of `col-2` (6 per row) to `col-6 col-sm-4 col-md-3 col-lg-2`. 
  - 2 per row on XS screens
  - 3 per row on SM screens
  - 4 per row on MD screens
  - 6 per row on XL screens

**Artist page**
- Organized logic to adjust column sizes based on presence of music videos. 
`col-<% if @artist.music_videos.present? %>3<% else %>2<% end %>` wasn't very readable.
  - Defined `releases_size_css` and `album_size_css` at the beginning and used those instead.
- Adjusted album sizes on smaller screens based on presence of music videos or not.
- Adjusted sizes of music videos on smaller screens.

