### PR TITLE
"Fix" for Singles Badge

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -95,13 +95,19 @@ $h1-font-size: $font-size-base * 1.5 !default;
   .card-title {
     font-size: 15px;
     font-weight: 100;
-    white-space: nowrap; 
-    text-overflow: ellipsis;
-    overflow: hidden;
     padding-bottom:2px;
     margin-bottom: 0.1rem;
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between; // or could be flex-start 
     a {
       color: $dark!important;
+      white-space: nowrap; 
+      text-overflow: ellipsis;
+      overflow: hidden;      
+    }
+    .badge {
+      margin-left: 0.25em;
     }
   }
   h6 {


### PR DESCRIPTION
Love the addition of singles badges in #31 ...
Currently long titles will push the singles badge out of view, so this fixes that with flexbox.

Currently have it set to `justify-content: space-between` so the badge stays flush right:
![image](https://user-images.githubusercontent.com/4490155/44795423-9e983300-ab78-11e8-8ccd-e462ad8e7d8b.png)

But could switch to `flex-start` to keep current formatting:
![image](https://user-images.githubusercontent.com/4490155/44795490-cc7d7780-ab78-11e8-9e3b-9787f5f14a97.png)