### PR TITLE
Add empty state message to albums view

### DIFF
--- a/app/views/albums/_album.html.erb
+++ b/app/views/albums/_album.html.erb
@@ -1,0 +1,16 @@
+<% cache album do %>
+  <div class="album">
+    <a href="<%= album_path(album) %>" class="album_cover">
+      <span class="sources">
+        <% if album.spotify_id %><i class="fab fa-spotify"></i><% end %> <% if album.applemusic_id %><i class="fab fa-apple"></i><% end %>
+      </span>
+      <img src="<%= album_image(album) %>" />
+    </a>
+    <% if album.album_type == 'single' %><span class="single" title="Single">S</span><% end %>
+    <%= link_to album.name, album_path(album), class: 'album-title' %>
+    <%= link_to album.artist.name, artist_path(album.artist), class: 'album-artist' %>
+    <% if album.release_date %>
+    <p class="release-date"><small><%= album.release_date.strftime("%B %-e, %Y") %></small></p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -1,30 +1,15 @@
 <% title "Latest Music Releases" %>
-<% if @albums.present? %>
 <h1>Albums</h1>
 <div class="latest-upcoming">
   <ul class="subnav">
     <li><%= link_to "Latest Releases", albums_path, class: 'active' %></li>
     <li><%= link_to "Upcoming Releases", upcoming_albums_path %></li>
   </ul>
+  <% if @albums.empty? %>
+    <p>No new albums, make sure to check back later!</p>
+  <% end %>
   <div class="album-grid">
-    <% @albums.each do |a| %>
-    <% cache a do %>
-      <div class="album">
-        <a href="<%= album_path(a) %>" class="album_cover">
-          <span class="sources">
-            <% if a.spotify_id %><i class="fab fa-spotify"></i><% end %> <% if a.applemusic_id %><i class="fab fa-apple"></i><% end %>
-          </span>
-          <img src="<%= album_image(a) %>" />
-        </a>
-        <% if a.album_type == 'single' %><span class="single" title="Single">S</span><% end %>
-        <%= link_to a.name, album_path(a), class: 'album-title' %>
-        <%= link_to a.artist.name, artist_path(a.artist), class: 'album-artist' %>
-        <% if a.release_date %>
-        <p class="release-date"><small><%= a.release_date.strftime("%B %-e, %Y") %></small></p>
-        <% end %>
-      </div>
-    <% end %>
-    <% end %>
+    <%= render(@albums) %>
   </div>
 </div>
 <!-- <div class="past-albums">
@@ -70,4 +55,3 @@
     </div>
   </div>
 </div> -->
-<% end %>

--- a/app/views/albums/index.html.erb
+++ b/app/views/albums/index.html.erb
@@ -9,7 +9,7 @@
     <p>No new albums, make sure to check back later!</p>
   <% end %>
   <div class="album-grid">
-    <%= render(@albums) %>
+    <%= render @albums %>
   </div>
 </div>
 <!-- <div class="past-albums">

--- a/app/views/albums/upcoming.html.erb
+++ b/app/views/albums/upcoming.html.erb
@@ -9,6 +9,6 @@
     <p>No new albums, make sure to check back later!</p>
   <% end %>
   <div class="album-grid">
-    <%= render(@albums) %>
+    <%= render @albums %>
   </div>
 </div>

--- a/app/views/albums/upcoming.html.erb
+++ b/app/views/albums/upcoming.html.erb
@@ -1,30 +1,14 @@
 <% title "Upcoming Music Releases" %>
-<% if @albums.present? %>
 <h1>Albums</h1>
 <div class="latest-upcoming">
   <ul class="subnav">
     <li><%= link_to "Latest Releases", albums_path %></li>
     <li><%= link_to "Upcoming Releases", upcoming_albums_path, class: 'active' %></li>
   </ul>
+  <% if @albums.empty? %>
+    <p>No new albums, make sure to check back later!</p>
+  <% end %>
   <div class="album-grid">
-    <% @albums.each do |a| %>
-    <% cache a do %>
-      <div class="album">
-        <a href="<%= album_path(a) %>" class="album_cover">
-          <span class="sources">
-            <% if a.spotify_id %><i class="fab fa-spotify"></i><% end %> <% if a.applemusic_id %><i class="fab fa-apple"></i><% end %>
-          </span>
-          <img src="<%= album_image(a) %>" />
-        </a>
-        <% if a.album_type == 'single' %><span class="single" title="Single">S</span><% end %>
-        <%= link_to a.name, album_path(a), class: 'album-title' %>
-        <%= link_to a.artist.name, artist_path(a.artist), class: 'album-artist' %>
-        <% if a.release_date %>
-        <p class="release-date"><small><%= a.release_date.strftime("%B %-e, %Y") %></small></p>
-        <% end %>
-      </div>
-    <% end %>
-    <% end %>
+    <%= render(@albums) %>
   </div>
 </div>
-<% end %>


### PR DESCRIPTION
Motivation behind this change is the albums page is the first thing users' see, and for some they will see a completely blank page. This makes the page not seem broken and explains to the user to check back later for anything new. Will also gladly add empty state messages to other views.

This might need a little more thought put into though, because when a user hasn't connected a Spotify/Apple Music the prompt to sign will show alongside this empty state.

Let me know what you think, and if the wording needs to change a little

- DRY up the albums view a little bit using rails' built `render @albums` that will render a partial for every item present.
- Adds an empty state message to make the page not look broken
- Changes album navigation to always show, this is more a quality of life change, but it's nice to be able to click back and forth between latest and upcoming.

Before:
![image](https://user-images.githubusercontent.com/2745145/44949741-baa40a80-adec-11e8-8962-31e88140aed0.png)

After:
![image](https://user-images.githubusercontent.com/2745145/44949743-c42d7280-adec-11e8-9571-434a3d3132b6.png)
